### PR TITLE
Distro update role

### DIFF
--- a/homelab.yml
+++ b/homelab.yml
@@ -3,7 +3,9 @@
   hosts: all
   become: yes
   roles:
-    - common
+    - role: common
+    - role: update
+      tags: update,never
 
 - name: Setup main Docker host
   hosts: docker.home.remigourdon.net

--- a/host_vars/builder.home.remigourdon.net
+++ b/host_vars/builder.home.remigourdon.net
@@ -4,3 +4,4 @@ vm_id: 203
 cores: 4
 memory: 4096
 disk_gb: 50
+update: yes

--- a/host_vars/docker.home.remigourdon.net
+++ b/host_vars/docker.home.remigourdon.net
@@ -4,3 +4,4 @@ vm_id: 202
 cores: 4
 memory: 16384
 disk_gb: 50
+update: yes

--- a/host_vars/endeavour.home.remigourdon.net
+++ b/host_vars/endeavour.home.remigourdon.net
@@ -4,3 +4,4 @@ vm_id: 200
 cores: 2
 memory: 2048
 disk_gb: 10
+update: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Update apt cache
-  apt:
-    cache_valid_time: 3600
-    update_cache: yes
-
 - name: Install apt repository management software
   apt:
     name:

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: Include update tasks
   include_tasks: ubuntu.yml
+  when: update

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Include update tasks
+  include_tasks: ubuntu.yml

--- a/roles/update/tasks/ubuntu.yml
+++ b/roles/update/tasks/ubuntu.yml
@@ -1,0 +1,20 @@
+---
+- name: Update apt repo and cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Upgrade all packages
+  apt:
+    upgrade: dist
+
+- name: Check if reboot is required
+  stat: 
+    path: /var/run/reboot-required
+  register: reboot_required
+
+- name: Reboot system if required
+  reboot:
+    msg: Rebooting to complete system upgrade
+    reboot_timeout: 120
+  when: reboot_required.stat.exists


### PR DESCRIPTION
Add a role to perform Ubuntu updates using a dedicated role that can be toggled for each host and is run only when the `update` tag is used on the `homelab.yml` playbook.