### PR TITLE
Proxmox Ubuntu VMs for K3s nodes

### DIFF
--- a/iac/README.md
+++ b/iac/README.md
@@ -6,7 +6,7 @@ Use the script as follows:
 
 ```sh
 ./create-proxmox-template.sh \
-    root@pve-1 \
+    root@pve-2 \
     https://cloud-images.ubuntu.com/jammy/20220924/jammy-server-cloudimg-amd64.img \
     8000 \
     ~/.ssh/id_ed25519.pub

--- a/iac/README.md
+++ b/iac/README.md
@@ -5,9 +5,33 @@
 Use the script as follows:
 
 ```sh
+cd iac/
 ./create-proxmox-template.sh \
     root@pve-2 \
     https://cloud-images.ubuntu.com/jammy/20220924/jammy-server-cloudimg-amd64.img \
     8000 \
     ~/.ssh/id_ed25519.pub
+```
+
+## Deploy with Terraform
+
+Export the following variables in the environment:
+
+```sh
+export PM_USER="terraform-prov@pve"
+export PM_PASS="<PASS>"
+```
+
+Initialize Terraform providers and modules:
+
+```sh
+cd iac/terraform/
+terraform init
+```
+
+Plan and apply, limiting parallelism because Proxmox API is slow and we want to avoid failures:
+
+```sh
+terraform plan
+terraform apply -parallelism=1
 ```

--- a/iac/README.md
+++ b/iac/README.md
@@ -1,0 +1,13 @@
+# Infrastructure as Code
+
+## Create cloud image template in Proxmox
+
+Use the script as follows:
+
+```sh
+./create-proxmox-template.sh \
+    root@pve-1 \
+    https://cloud-images.ubuntu.com/jammy/20220924/jammy-server-cloudimg-amd64.img \
+    8000 \
+    ~/.ssh/id_ed25519.pub
+```

--- a/iac/create-proxmox-template.sh
+++ b/iac/create-proxmox-template.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+###############
+# DEFINITIONS #
+###############
+
+VM_POOL="local-zfs"
+
+#########
+# USAGE #
+#########
+
+usage() {
+    echo "Usage: $(basename "${0}") [OPTIONS] SSH_HOST IMG_URL TEMPLATE_ID CLOUDINIT_SSH_PUB
+
+Create VM template from a cloud image.
+
+OPTIONS:
+    -h    Display this message"
+}
+
+################
+# ARGS PARSING #
+################
+
+if [[ ${#} -ne 4 ]] ; then
+    usage
+    exit 1
+else
+    SSH_HOST="${1}"
+    IMG_URL="${2}"
+    TEMPLATE_ID="${3}"
+    CLOUDINIT_SSH_PUB="${4}"
+
+    IMG_NAME="$(basename "${IMG_URL}")"
+fi
+
+##########
+# ACTION #
+##########
+
+# Copy SSH public keys to Proxmox
+CLOUDINIT_SSH_PUB_PROXMOX="${IMG_NAME%.img}-ssh.pub"
+scp -q "${CLOUDINIT_SSH_PUB}" "${SSH_HOST}":"${CLOUDINIT_SSH_PUB_PROXMOX}"
+
+ssh -T "${SSH_HOST}" <<EOI
+
+# Get image from URL (won't redownload if already there)
+wget --continue --quiet "${IMG_URL}"
+
+# Create and configure VM (exit if already exists)
+qm create "${TEMPLATE_ID}" \
+    --name "${IMG_NAME%.img}" \
+    --description "${IMG_NAME%.img} (created on $(date --utc --iso-8601=seconds))" \
+    --memory 2048 \
+    --core 2 \
+    --net0 virtio,bridge=vmbr0 \
+    --serial0 socket --vga serial0 \
+    --boot "order=scsi0;ide2;net0" || exit 1
+
+# Import and mount cloud image disk
+qm importdisk "${TEMPLATE_ID}" "${IMG_NAME}" "${VM_POOL}"
+qm set "${TEMPLATE_ID}" \
+    --scsihw virtio-scsi-pci \
+    --scsi0 "${VM_POOL}:vm-${TEMPLATE_ID}-disk-0"
+
+# Configure Cloud-Init
+qm set "${TEMPLATE_ID}" \
+    --ide2 "${VM_POOL}:cloudinit" \
+    --ciuser "server-admin" \
+    --sshkeys "${CLOUDINIT_SSH_PUB_PROXMOX}" \
+    --ipconfig0 ",ip=dhcp"
+
+# Create template from this VM
+qm template "${TEMPLATE_ID}"
+EOI

--- a/iac/create-proxmox-template.sh
+++ b/iac/create-proxmox-template.sh
@@ -65,13 +65,6 @@ qm set "${TEMPLATE_ID}" \
     --scsihw virtio-scsi-pci \
     --scsi0 "${VM_POOL}:vm-${TEMPLATE_ID}-disk-0"
 
-# Configure Cloud-Init
-qm set "${TEMPLATE_ID}" \
-    --ide2 "${VM_POOL}:cloudinit" \
-    --ciuser "server-admin" \
-    --sshkeys "${CLOUDINIT_SSH_PUB_PROXMOX}" \
-    --ipconfig0 ",ip=dhcp"
-
 # Create template from this VM
 qm template "${TEMPLATE_ID}"
 EOI

--- a/iac/create-proxmox-template.sh
+++ b/iac/create-proxmox-template.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2087
 set -Eeuo pipefail
 
 ###############

--- a/iac/create-proxmox-template.sh
+++ b/iac/create-proxmox-template.sh
@@ -65,6 +65,9 @@ qm set "${TEMPLATE_ID}" \
     --scsihw virtio-scsi-pci \
     --scsi0 "${VM_POOL}:vm-${TEMPLATE_ID}-disk-0"
 
+# Configure Cloud-Init
+qm set "${TEMPLATE_ID}" --ide2 "${VM_POOL}:cloudinit"
+
 # Create template from this VM
 qm template "${TEMPLATE_ID}"
 EOI

--- a/iac/terraform/.gitignore
+++ b/iac/terraform/.gitignore
@@ -1,0 +1,37 @@
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/iac/terraform/.terraform.lock.hcl
+++ b/iac/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/telmate/proxmox" {
+  version     = "2.9.11"
+  constraints = "2.9.11"
+  hashes = [
+    "h1:RKM2pvHNJrQKcMD7omaPiM099vWGgDnnZqn1kGknYXU=",
+    "zh:0db1e3940cf208e56919e68c6d557dfc87d380316a474c8999916308bf991440",
+    "zh:2a0ae7af5b2f96d53b24f34575bc72ccbb79cab870901f26f00a301613f7c69e",
+    "zh:2f9eb4a4d2c5db04ec0940d7e250aaf1bac559acc787a5883688ba42159f8b8e",
+    "zh:362a5b44995a51c8de78f0106aa7741f212bb15fbf2d7477794ea3ee63e2c17d",
+    "zh:4d212404b741848cef1e469e390ad1df659bbfa8d47cd079d82d83c288925438",
+    "zh:54a65a01946839db263f8da389791863f6909db9d5fcfdb472e23b14883a5b6c",
+    "zh:5dfc95303efc53686b23762dfa4c50d887eb4cc0a3e9d527adc29b3a9f0439eb",
+    "zh:68db84c007cbdd7267d1f7b767b0b2b91e9ee2e2b92ac1d8a1568f3bc61e67cd",
+    "zh:85d45466445883ae64eed3d5fcb996de389ecf9268f0f7d2f22911fb3f56a344",
+    "zh:8673f8c794ea8413dc9a3933902492b3e5be99e79bc611fcef415be7d7268210",
+    "zh:d5041f72f550f3c81dafecb4e7dfca9f849737154a0e2c81434df6c72d75af25",
+    "zh:e60e03b495dd76660784a8ab07d8db0ce1df7165e713efb350c1864d92f87a8c",
+    "zh:ed1f75a2fe7d764356119a590f301ab8fd40cfeea78a514450868beb92115f28",
+    "zh:efa4140b78775509665370c915e60c9043a1325d608f96da151f8f7fcc7cb45e",
+  ]
+}

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "2.9.11"
+    }
+  }
+}
+
+provider "proxmox" {
+  pm_api_url      = "https://pve-1.home.remigourdon.net:8006/api2/json"
+  pm_debug        = true
+  pm_tls_insecure = true
+}
+
+resource "proxmox_vm_qemu" "resource-name" {
+  name        = "ubuntu-test"
+  target_node = "pve-1"
+  clone       = "jammy-server-cloudimg-amd64"
+  full_clone  = true
+}

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -16,18 +16,23 @@ provider "proxmox" {
 locals {
   nodes = {
     "k3s-01" = {
+      vm_id       = 301
       mac_address = "74:3e:14:61:69:32"
     },
     "k3s-02" = {
+      vm_id       = 302
       mac_address = "83:6b:28:c2:f2:7c"
     },
     "k3s-03" = {
+      vm_id       = 303
       mac_address = "97:cd:33:40:7b:de"
     },
     "k3s-04" = {
+      vm_id       = 304
       mac_address = "a2:9f:15:c8:87:f6"
     },
     "k3s-05" = {
+      vm_id       = 305
       mac_address = "b6:dc:7e:00:f5:f9"
     }
   }
@@ -38,5 +43,6 @@ module "k3s-node" {
   source       = "./modules/k3s-node"
   name         = each.key
   proxmox_node = "pve-1"
+  vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
 }

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -28,13 +28,13 @@ locals {
     "k3s-01" = {
       vm_id         = 301
       proxmox_node  = "pve-1"
-      mac_address   = "74:3e:14:61:69:32"
+      mac_address   = "74:3E:14:61:69:32"
       is_k3s_server = true
     },
     "k3s-02" = {
       vm_id         = 302
       proxmox_node  = "pve-1"
-      mac_address   = "83:6b:28:c2:f2:7c"
+      mac_address   = "83:6B:28:C2:F2:7C"
       is_k3s_server = true
     },
   }
@@ -42,19 +42,19 @@ locals {
     "k3s-03" = {
       vm_id         = 303
       proxmox_node  = "pve-2"
-      mac_address   = "97:cd:33:40:7b:de"
+      mac_address   = "97:CD:33:40:7B:DE"
       is_k3s_server = true
     },
     "k3s-04" = {
       vm_id         = 304
       proxmox_node  = "pve-2"
-      mac_address   = "a2:9f:15:c8:87:f6"
+      mac_address   = "A2:9F:15:C8:87:F6"
       is_k3s_server = false
     },
     "k3s-05" = {
       vm_id         = 305
       proxmox_node  = "pve-2"
-      mac_address   = "b6:dc:7e:00:f5:f9"
+      mac_address   = "B6:DC:7E:00:F5:F9"
       is_k3s_server = false
     }
   }

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -67,6 +67,7 @@ module "pve-1-nodes" {
     proxmox = proxmox.pve1
   }
   name         = each.key
+  description  = "K3s ${each.value.is_k3s_server ? "server" : "agent"}"
   proxmox_node = each.value.proxmox_node
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
@@ -81,6 +82,7 @@ module "pve-2-nodes" {
     proxmox = proxmox.pve2
   }
   name         = each.key
+  description  = "K3s ${each.value.is_k3s_server ? "server" : "agent"}"
   proxmox_node = each.value.proxmox_node
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "proxmox" {
-  pm_api_url      = "https://pve-1.home.remigourdon.net:8006/api2/json"
+  pm_api_url      = "https://pve-2.home.remigourdon.net:8006/api2/json"
   pm_debug        = true
   pm_tls_insecure = true
 }
@@ -42,7 +42,7 @@ module "k3s-node" {
   for_each     = local.nodes
   source       = "./modules/k3s-node"
   name         = each.key
-  proxmox_node = "pve-1"
+  proxmox_node = "pve-2"
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
 }

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -34,7 +34,7 @@ locals {
     "k3s-02" = {
       vm_id         = 302
       proxmox_node  = "pve-1"
-      mac_address   = "83:6B:28:C2:F2:7C"
+      mac_address   = "82:6B:28:C2:F2:7C"
       is_k3s_server = true
     },
   }
@@ -42,7 +42,7 @@ locals {
     "k3s-03" = {
       vm_id         = 303
       proxmox_node  = "pve-2"
-      mac_address   = "97:CD:33:40:7B:DE"
+      mac_address   = "96:CD:33:40:7B:DE"
       is_k3s_server = true
     },
     "k3s-04" = {

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -13,9 +13,30 @@ provider "proxmox" {
   pm_tls_insecure = true
 }
 
-resource "proxmox_vm_qemu" "resource-name" {
-  name        = "ubuntu-test"
-  target_node = "pve-1"
-  clone       = "jammy-server-cloudimg-amd64"
-  full_clone  = true
+locals {
+  nodes = {
+    "k3s-01" = {
+      mac_address = "74:3e:14:61:69:32"
+    },
+    "k3s-02" = {
+      mac_address = "83:6b:28:c2:f2:7c"
+    },
+    "k3s-03" = {
+      mac_address = "97:cd:33:40:7b:de"
+    },
+    "k3s-04" = {
+      mac_address = "a2:9f:15:c8:87:f6"
+    },
+    "k3s-05" = {
+      mac_address = "b6:dc:7e:00:f5:f9"
+    }
+  }
+}
+
+module "k3s-node" {
+  for_each     = local.nodes
+  source       = "./modules/k3s-node"
+  name         = each.key
+  proxmox_node = "pve-1"
+  mac_address  = each.value.mac_address
 }

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -7,42 +7,74 @@ terraform {
   }
 }
 
+# Proxmox server on HPE Proliant
 provider "proxmox" {
+  alias           = "pve1"
+  pm_api_url      = "https://pve-1.home.remigourdon.net:8006/api2/json"
+  pm_debug        = true
+  pm_tls_insecure = true
+}
+
+# Proxmox server on Intel NUC
+provider "proxmox" {
+  alias           = "pve2"
   pm_api_url      = "https://pve-2.home.remigourdon.net:8006/api2/json"
   pm_debug        = true
   pm_tls_insecure = true
 }
 
 locals {
-  nodes = {
+  pve_1_nodes = {
     "k3s-01" = {
-      vm_id       = 301
-      mac_address = "74:3e:14:61:69:32"
+      vm_id        = 301
+      proxmox_node = "pve-1"
+      mac_address  = "74:3e:14:61:69:32"
     },
     "k3s-02" = {
-      vm_id       = 302
-      mac_address = "83:6b:28:c2:f2:7c"
+      vm_id        = 302
+      proxmox_node = "pve-1"
+      mac_address  = "83:6b:28:c2:f2:7c"
     },
+  }
+  pve_2_nodes = {
     "k3s-03" = {
-      vm_id       = 303
-      mac_address = "97:cd:33:40:7b:de"
+      vm_id        = 303
+      proxmox_node = "pve-2"
+      mac_address  = "97:cd:33:40:7b:de"
     },
     "k3s-04" = {
-      vm_id       = 304
-      mac_address = "a2:9f:15:c8:87:f6"
+      vm_id        = 304
+      proxmox_node = "pve-2"
+      mac_address  = "a2:9f:15:c8:87:f6"
     },
     "k3s-05" = {
-      vm_id       = 305
-      mac_address = "b6:dc:7e:00:f5:f9"
+      vm_id        = 305
+      proxmox_node = "pve-2"
+      mac_address  = "b6:dc:7e:00:f5:f9"
     }
   }
 }
 
-module "k3s-node" {
-  for_each     = local.nodes
-  source       = "./modules/k3s-node"
+module "pve-1-nodes" {
+  source   = "./modules/k3s-node"
+  for_each = local.pve_1_nodes
+  providers = {
+    proxmox = proxmox.pve1
+  }
   name         = each.key
-  proxmox_node = "pve-2"
+  proxmox_node = each.value.proxmox_node
+  vm_id        = each.value.vm_id
+  mac_address  = each.value.mac_address
+}
+
+module "pve-2-nodes" {
+  source   = "./modules/k3s-node"
+  for_each = local.pve_2_nodes
+  providers = {
+    proxmox = proxmox.pve2
+  }
+  name         = each.key
+  proxmox_node = each.value.proxmox_node
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
 }

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -26,31 +26,36 @@ provider "proxmox" {
 locals {
   pve_1_nodes = {
     "k3s-01" = {
-      vm_id        = 301
-      proxmox_node = "pve-1"
-      mac_address  = "74:3e:14:61:69:32"
+      vm_id         = 301
+      proxmox_node  = "pve-1"
+      mac_address   = "74:3e:14:61:69:32"
+      is_k3s_server = true
     },
     "k3s-02" = {
-      vm_id        = 302
-      proxmox_node = "pve-1"
-      mac_address  = "83:6b:28:c2:f2:7c"
+      vm_id         = 302
+      proxmox_node  = "pve-1"
+      mac_address   = "83:6b:28:c2:f2:7c"
+      is_k3s_server = true
     },
   }
   pve_2_nodes = {
     "k3s-03" = {
-      vm_id        = 303
-      proxmox_node = "pve-2"
-      mac_address  = "97:cd:33:40:7b:de"
+      vm_id         = 303
+      proxmox_node  = "pve-2"
+      mac_address   = "97:cd:33:40:7b:de"
+      is_k3s_server = true
     },
     "k3s-04" = {
-      vm_id        = 304
-      proxmox_node = "pve-2"
-      mac_address  = "a2:9f:15:c8:87:f6"
+      vm_id         = 304
+      proxmox_node  = "pve-2"
+      mac_address   = "a2:9f:15:c8:87:f6"
+      is_k3s_server = false
     },
     "k3s-05" = {
-      vm_id        = 305
-      proxmox_node = "pve-2"
-      mac_address  = "b6:dc:7e:00:f5:f9"
+      vm_id         = 305
+      proxmox_node  = "pve-2"
+      mac_address   = "b6:dc:7e:00:f5:f9"
+      is_k3s_server = false
     }
   }
 }
@@ -65,6 +70,8 @@ module "pve-1-nodes" {
   proxmox_node = each.value.proxmox_node
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
+  cores        = each.value.is_k3s_server ? 2 : 4
+  memory       = each.value.is_k3s_server ? 2048 : 4096
 }
 
 module "pve-2-nodes" {
@@ -77,4 +84,6 @@ module "pve-2-nodes" {
   proxmox_node = each.value.proxmox_node
   vm_id        = each.value.vm_id
   mac_address  = each.value.mac_address
+  cores        = each.value.is_k3s_server ? 2 : 4
+  memory       = each.value.is_k3s_server ? 2048 : 4096
 }

--- a/iac/terraform/modules/k3s-node/main.tf
+++ b/iac/terraform/modules/k3s-node/main.tf
@@ -32,4 +32,9 @@ resource "proxmox_vm_qemu" "k3s-node" {
     macaddr = var.mac_address
     bridge  = "vmbr0"
   }
+
+  # Cloud Init
+  ciuser    = "server-admin"
+  ipconfig0 = ",ip=dhcp"
+  sshkeys   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIItabw8pTiKUQn2EENw7EyTfXm/OgrpI7+Sc+hH2N8Ge remi@frame-home"
 }

--- a/iac/terraform/modules/k3s-node/main.tf
+++ b/iac/terraform/modules/k3s-node/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "2.9.11"
+    }
+  }
+}
+
+resource "proxmox_vm_qemu" "k3s-node" {
+  name        = var.name
+  target_node = var.proxmox_node
+  clone       = "jammy-server-cloudimg-amd64"
+  full_clone  = true
+
+  oncreate = true
+  onboot   = true
+
+  cores  = 4
+  memory = 4096
+
+  scsihw = "virtio-scsi-pci"
+  disk {
+    type    = "scsi"
+    storage = "local-zfs"
+    size    = "10G"
+  }
+
+  network {
+    model   = "virtio"
+    macaddr = var.mac_address
+    bridge  = "vmbr0"
+  }
+}

--- a/iac/terraform/modules/k3s-node/main.tf
+++ b/iac/terraform/modules/k3s-node/main.tf
@@ -17,14 +17,14 @@ resource "proxmox_vm_qemu" "k3s-node" {
   oncreate = true
   onboot   = true
 
-  cores  = 4
-  memory = 4096
+  cores  = var.cores
+  memory = var.memory
 
   scsihw = "virtio-scsi-pci"
   disk {
     type    = "scsi"
     storage = "local-zfs"
-    size    = "10G"
+    size    = var.disk_size
   }
 
   network {

--- a/iac/terraform/modules/k3s-node/main.tf
+++ b/iac/terraform/modules/k3s-node/main.tf
@@ -8,7 +8,9 @@ terraform {
 }
 
 resource "proxmox_vm_qemu" "k3s-node" {
-  name        = var.name
+  name = var.name
+  desc = var.description
+
   target_node = var.proxmox_node
   vmid        = var.vm_id
   clone       = "jammy-server-cloudimg-amd64"

--- a/iac/terraform/modules/k3s-node/main.tf
+++ b/iac/terraform/modules/k3s-node/main.tf
@@ -10,6 +10,7 @@ terraform {
 resource "proxmox_vm_qemu" "k3s-node" {
   name        = var.name
   target_node = var.proxmox_node
+  vmid        = var.vm_id
   clone       = "jammy-server-cloudimg-amd64"
   full_clone  = true
 

--- a/iac/terraform/modules/k3s-node/variables.tf
+++ b/iac/terraform/modules/k3s-node/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   description = "Name of the K3s node VM"
 }
 
+variable "description" {
+  type        = string
+  description = "Name of the K3s node VM"
+}
+
 variable "proxmox_node" {
   type        = string
   description = "Proxmox node to deploy VM onto"

--- a/iac/terraform/modules/k3s-node/variables.tf
+++ b/iac/terraform/modules/k3s-node/variables.tf
@@ -8,6 +8,12 @@ variable "proxmox_node" {
   description = "Proxmox node to deploy VM onto"
 }
 
+variable "vm_id" {
+  type        = number
+  default     = 0
+  description = "ID to use for the VM (0 uses next available)"
+}
+
 variable "mac_address" {
   type        = string
   description = "MAC address to use for the node's main interface"

--- a/iac/terraform/modules/k3s-node/variables.tf
+++ b/iac/terraform/modules/k3s-node/variables.tf
@@ -18,3 +18,21 @@ variable "mac_address" {
   type        = string
   description = "MAC address to use for the node's main interface"
 }
+
+variable "cores" {
+  type        = number
+  description = "CPU cores to dedicate to the VM"
+  default     = 4
+}
+
+variable "memory" {
+  type        = number
+  description = "Memory to dedicate to the VM (in MB)"
+  default     = 4096
+}
+
+variable "disk_size" {
+  type        = string
+  description = "Disk size for the VM"
+  default     = "10G"
+}

--- a/iac/terraform/modules/k3s-node/variables.tf
+++ b/iac/terraform/modules/k3s-node/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type        = string
+  description = "Name of the K3s node VM"
+}
+
+variable "proxmox_node" {
+  type        = string
+  description = "Proxmox node to deploy VM onto"
+}
+
+variable "mac_address" {
+  type        = string
+  description = "MAC address to use for the node's main interface"
+}


### PR DESCRIPTION
This PR:

+ adds a Bash script to create a Proxmox template from an Ubuntu Cloud Image
+ uses this Template with the [Proxmox Terraform provider](https://registry.terraform.io/providers/Telmate/proxmox/latest/docs) to create 5 VMs on my 2 Proxmox servers, that will be used as 3 K3s servers and 2 K3s workers